### PR TITLE
consumer: expose per-connection RDY and in-flight via ConnStats

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -260,6 +260,12 @@ func (c *Conn) MaxRDY() int64 {
 	return c.maxRdyCount
 }
 
+// MessagesInFlight returns the number of messages currently in flight
+// (sent by nsqd over this connection, not yet finished or requeued).
+func (c *Conn) MessagesInFlight() int64 {
+	return atomic.LoadInt64(&c.messagesInFlight)
+}
+
 // LastRdyTime returns the time of the last non-zero RDY
 // update for this connection
 func (c *Conn) LastRdyTime() time.Time {

--- a/connstats_test.go
+++ b/connstats_test.go
@@ -1,0 +1,50 @@
+package nsq
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+// TestConnStatsReportsPerConnRDYAndInFlight verifies ConnStats returns the
+// per-nsqd RDY and in-flight counts for each connection.
+func TestConnStatsReportsPerConnRDYAndInFlight(t *testing.T) {
+	config := NewConfig()
+	config.MaxInFlight = 10
+	consumer, err := NewConsumer("test", "ch", config)
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	close(consumer.exitChan) // quiesce rdyLoop
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	mk := func(addr string, rdy, inflight int64) {
+		conn := NewConn(addr, &consumer.config, &consumerConnDelegate{r: consumer})
+		conn.SetRDY(rdy)
+		atomic.StoreInt64(&conn.messagesInFlight, inflight)
+		consumer.mtx.Lock()
+		consumer.connections[addr] = conn
+		consumer.mtx.Unlock()
+	}
+	mk("10.0.0.1:4150", 3, 2)
+	mk("10.0.0.2:4150", 0, 0)
+
+	got := map[string]ConnStat{}
+	for _, s := range consumer.ConnStats() {
+		got[s.Address] = s
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 conn stats, got %d", len(got))
+	}
+	if s := got["10.0.0.1:4150"]; s.RDY != 3 || s.InFlight != 2 {
+		t.Fatalf("conn1: want RDY 3 inflight 2, got RDY %d inflight %d", s.RDY, s.InFlight)
+	}
+	if s := got["10.0.0.2:4150"]; s.RDY != 0 || s.InFlight != 0 {
+		t.Fatalf("conn2: want RDY 0 inflight 0, got RDY %d inflight %d", s.RDY, s.InFlight)
+	}
+}

--- a/consumer.go
+++ b/consumer.go
@@ -205,6 +205,31 @@ func (r *Consumer) Stats() *ConsumerStats {
 	}
 }
 
+// ConnStat is a point-in-time view of a single nsqd connection's RDY and
+// in-flight counts, keyed by the nsqd address.
+type ConnStat struct {
+	Address  string
+	RDY      int64
+	InFlight int64
+}
+
+// ConnStats returns per-connection RDY and in-flight counts for every nsqd
+// the consumer is currently connected to. It exists so callers can observe
+// how the MaxInFlight budget is distributed across connections (e.g. to spot
+// a single nsqd being under-provisioned with RDY relative to its peers).
+func (r *Consumer) ConnStats() []ConnStat {
+	conns := r.conns()
+	stats := make([]ConnStat, 0, len(conns))
+	for _, c := range conns {
+		stats = append(stats, ConnStat{
+			Address:  c.String(),
+			RDY:      c.RDY(),
+			InFlight: c.MessagesInFlight(),
+		})
+	}
+	return stats
+}
+
 func (r *Consumer) conns() []*Conn {
 	r.mtx.RLock()
 	conns := make([]*Conn, 0, len(r.connections))


### PR DESCRIPTION
## Why
`Consumer.Stats()` only reports fleet aggregates (received/finished/requeued/connection-count). There's no way to see how the per-consumer `MaxInFlight` budget is distributed across the individual nsqd connections.

We need this to diagnose/monitor a production issue where a single nsqd (typically a freshly-rolled one) is consumed at roughly half the rate of its peers — equal produce and equal connection count, but lower per-connection RDY. Without per-connection visibility we can only infer it from nsqd-side aggregates.

## What
- `Conn.MessagesInFlight() int64` — public accessor for the existing in-flight counter (mirrors `Conn.RDY()`).
- `Consumer.ConnStats() []ConnStat` — per-nsqd `{Address, RDY, InFlight}`.

Read-only; no behaviour change. Lets a consumer export per-server RDY/in-flight gauges (no debug logging needed).

## Test
`TestConnStatsReportsPerConnRDYAndInFlight`.