### PR TITLE
consumer: rebalance RDY across all connections on connection-set change

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -260,6 +260,12 @@ func (c *Conn) MaxRDY() int64 {
 	return c.maxRdyCount
 }
 
+// MessagesInFlight returns the number of messages currently in flight
+// (sent by nsqd over this connection, not yet finished or requeued).
+func (c *Conn) MessagesInFlight() int64 {
+	return atomic.LoadInt64(&c.messagesInFlight)
+}
+
 // LastRdyTime returns the time of the last non-zero RDY
 // update for this connection
 func (c *Conn) LastRdyTime() time.Time {

--- a/connstats_test.go
+++ b/connstats_test.go
@@ -1,0 +1,50 @@
+package nsq
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+// TestConnStatsReportsPerConnRDYAndInFlight verifies ConnStats returns the
+// per-nsqd RDY and in-flight counts for each connection.
+func TestConnStatsReportsPerConnRDYAndInFlight(t *testing.T) {
+	config := NewConfig()
+	config.MaxInFlight = 10
+	consumer, err := NewConsumer("test", "ch", config)
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	close(consumer.exitChan) // quiesce rdyLoop
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	mk := func(addr string, rdy, inflight int64) {
+		conn := NewConn(addr, &consumer.config, &consumerConnDelegate{r: consumer})
+		conn.SetRDY(rdy)
+		atomic.StoreInt64(&conn.messagesInFlight, inflight)
+		consumer.mtx.Lock()
+		consumer.connections[addr] = conn
+		consumer.mtx.Unlock()
+	}
+	mk("10.0.0.1:4150", 3, 2)
+	mk("10.0.0.2:4150", 0, 0)
+
+	got := map[string]ConnStat{}
+	for _, s := range consumer.ConnStats() {
+		got[s.Address] = s
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 conn stats, got %d", len(got))
+	}
+	if s := got["10.0.0.1:4150"]; s.RDY != 3 || s.InFlight != 2 {
+		t.Fatalf("conn1: want RDY 3 inflight 2, got RDY %d inflight %d", s.RDY, s.InFlight)
+	}
+	if s := got["10.0.0.2:4150"]; s.RDY != 0 || s.InFlight != 0 {
+		t.Fatalf("conn2: want RDY 0 inflight 0, got RDY %d inflight %d", s.RDY, s.InFlight)
+	}
+}

--- a/consumer.go
+++ b/consumer.go
@@ -943,7 +943,10 @@ func (r *Consumer) maybeUpdateRDY(conn *Conn) {
 
 // rebalanceRDY resets every connection to its fair share of MaxInFlight so a
 // connection added or freed by a roll (or a MaxInFlight change) gets its share
-// instead of being starved by the ones already holding the budget.
+// instead of being starved by the ones already holding the budget. It is called
+// on every connection-set change and periodically from rdyLoop, so a starved
+// connection recovers within one RDYRedistributeInterval regardless of whether
+// MaxInFlight ever changes again.
 func (r *Consumer) rebalanceRDY() {
 	if r.inBackoff() || r.inBackoffTimeout() {
 		return
@@ -971,6 +974,15 @@ func (r *Consumer) rdyLoop() {
 		select {
 		case <-redistributeTicker.C:
 			r.redistributeRDY()
+			// Re-assert fair shares every tick: RDY is otherwise only set on
+			// connect/close/ChangeMaxInFlight, so a connection rolled onto a
+			// consumer whose MaxInFlight stays constant would keep whatever
+			// (near-zero) RDY it got at connect and stay starved indefinitely.
+			// Skip when over-subscribed: there a fair share is < 1 RDY/conn and
+			// redistributeRDY (above) owns rotating the scarce budget instead.
+			if int64(len(r.conns())) <= int64(r.getMaxInFlight()) {
+				r.rebalanceRDY()
+			}
 		case <-r.exitChan:
 			goto exit
 		}

--- a/consumer.go
+++ b/consumer.go
@@ -345,9 +345,9 @@ func (r *Consumer) ChangeMaxInFlight(maxInFlight int) {
 
 	atomic.StoreInt32(&r.maxInFlight, int32(maxInFlight))
 
-	for _, c := range r.conns() {
-		r.maybeUpdateRDY(c)
-	}
+	// re-assert each connection's share of the new budget (lower-first, so an
+	// under-share connection is not refused by the ones already holding it)
+	r.rebalanceRDY()
 }
 
 // set lookupd http client
@@ -630,13 +630,8 @@ func (r *Consumer) ConnectToNSQD(addr string) error {
 	r.connections[addr] = conn
 	r.mtx.Unlock()
 
-	// pre-emptive signal to existing connections to lower their RDY count
-	for _, c := range r.conns() {
-		if c != conn {
-			r.maybeUpdateRDY(c)
-		}
-	}
-	r.maybeUpdateRDY(conn)
+	// give the newly added connection its fair share of RDY
+	r.rebalanceRDY()
 
 	return nil
 }
@@ -785,6 +780,9 @@ func (r *Consumer) onConnClose(c *Conn) {
 		}
 		return
 	}
+
+	// hand the freed budget to the remaining connections
+	r.rebalanceRDY()
 
 	r.mtx.RLock()
 	numLookupd := len(r.lookupdHTTPAddrs)
@@ -940,6 +938,29 @@ func (r *Consumer) maybeUpdateRDY(conn *Conn) {
 	r.log(LogLevelDebug, "(%s) sending RDY %d", conn, count)
 	if err := r.updateRDY(conn, count); err != nil {
 		r.log(LogLevelWarning, "(%s) error sending RDY %d: %v", conn, count, err)
+	}
+}
+
+// rebalanceRDY resets every connection to its fair share of MaxInFlight so a
+// connection added or freed by a roll (or a MaxInFlight change) gets its share
+// instead of being starved by the ones already holding the budget.
+func (r *Consumer) rebalanceRDY() {
+	if r.inBackoff() || r.inBackoffTimeout() {
+		return
+	}
+	count := r.perConnMaxInFlight()
+	conns := r.conns()
+	// lower over-share connections first to free budget, then raise the rest
+	// (updateRDY errors are ignored; it reschedules refused RDY-0 conns itself)
+	for _, c := range conns {
+		if c.RDY() > count {
+			_ = r.updateRDY(c, count)
+		}
+	}
+	for _, c := range conns {
+		if c.RDY() < count {
+			_ = r.updateRDY(c, count)
+		}
 	}
 }
 

--- a/consumer.go
+++ b/consumer.go
@@ -211,6 +211,10 @@ type ConnStat struct {
 	Address  string
 	RDY      int64
 	InFlight int64
+	// Closing is true while the connection is being torn down. A closing
+	// connection still counts toward totalRdyCount but updateRDY refuses to
+	// change its RDY, so its budget cannot be reclaimed until it is removed.
+	Closing bool
 }
 
 // ConnStats returns per-connection RDY and in-flight counts for every nsqd
@@ -225,6 +229,7 @@ func (r *Consumer) ConnStats() []ConnStat {
 			Address:  c.String(),
 			RDY:      c.RDY(),
 			InFlight: c.MessagesInFlight(),
+			Closing:  c.IsClosing(),
 		})
 	}
 	return stats
@@ -330,6 +335,14 @@ func (r *Consumer) IsStarved() bool {
 
 func (r *Consumer) getMaxInFlight() int32 {
 	return atomic.LoadInt32(&r.maxInFlight)
+}
+
+// TotalRDY returns the consumer's running total of RDY advertised across all
+// connections (the budget tracked against MaxInFlight). Comparing it to the sum
+// of per-connection RDY reveals budget leaked by connections that were removed
+// or are stuck closing without their RDY being reclaimed.
+func (r *Consumer) TotalRDY() int64 {
+	return atomic.LoadInt64(&r.totalRdyCount)
 }
 
 // ChangeMaxInFlight sets a new maximum number of messages this comsumer instance

--- a/consumer.go
+++ b/consumer.go
@@ -1025,9 +1025,18 @@ func (r *Consumer) updateRDY(c *Conn, count int64) error {
 	}
 	r.rdyRetryMtx.Unlock()
 
+	// lowering (or leaving) a connection's RDY only frees budget, so always
+	// allow it; the over-max-in-flight guard below must apply to raises only.
+	// otherwise, once totalRdyCount exceeds MaxInFlight (e.g. right after
+	// MaxInFlight is reduced) every reduction is refused too, the budget can
+	// never be brought back down, and connections added later are starved.
+	rdyCount := c.RDY()
+	if count <= rdyCount {
+		return r.sendRDY(c, count)
+	}
+
 	// never exceed our global max in flight. truncate if possible.
 	// this could help a new connection get partial max-in-flight
-	rdyCount := c.RDY()
 	maxPossibleRdy := int64(r.getMaxInFlight()) - atomic.LoadInt64(&r.totalRdyCount) + rdyCount
 	if maxPossibleRdy > 0 && maxPossibleRdy < count {
 		count = maxPossibleRdy

--- a/consumer.go
+++ b/consumer.go
@@ -205,6 +205,31 @@ func (r *Consumer) Stats() *ConsumerStats {
 	}
 }
 
+// ConnStat is a point-in-time view of a single nsqd connection's RDY and
+// in-flight counts, keyed by the nsqd address.
+type ConnStat struct {
+	Address  string
+	RDY      int64
+	InFlight int64
+}
+
+// ConnStats returns per-connection RDY and in-flight counts for every nsqd
+// the consumer is currently connected to. It exists so callers can observe
+// how the MaxInFlight budget is distributed across connections (e.g. to spot
+// a single nsqd being under-provisioned with RDY relative to its peers).
+func (r *Consumer) ConnStats() []ConnStat {
+	conns := r.conns()
+	stats := make([]ConnStat, 0, len(conns))
+	for _, c := range conns {
+		stats = append(stats, ConnStat{
+			Address:  c.String(),
+			RDY:      c.RDY(),
+			InFlight: c.MessagesInFlight(),
+		})
+	}
+	return stats
+}
+
 func (r *Consumer) conns() []*Conn {
 	r.mtx.RLock()
 	conns := make([]*Conn, 0, len(r.connections))

--- a/maxinflight_decrease_test.go
+++ b/maxinflight_decrease_test.go
@@ -1,0 +1,88 @@
+package nsq
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+// TestMaxInFlightDecreaseLowersRDY reproduces the budget over-commitment bug.
+//
+// Six connections share MaxInFlight=18 at their fair share (RDY 3 each,
+// totalRdyCount=18). The manager then lowers MaxInFlight to 12. RDY must follow
+// down to perConn=2 each (totalRdyCount=12).
+//
+// It does NOT, because updateRDY refuses every call with count>0 once
+// totalRdyCount > MaxInFlight — including calls that *lower* a connection. So
+// rebalanceRDY's lower-pass is refused on every connection, totalRdyCount stays
+// pinned at 18 (above the new budget of 12), and the over-commitment can never
+// unwind. A connection added afterwards is then refused RDY and starves.
+//
+// This test asserts the correct behaviour, so it fails on the current code
+// (reproducing the bug) and passes once the lowering path is allowed.
+func TestMaxInFlightDecreaseLowersRDY(t *testing.T) {
+	const numConns = 6
+	config := NewConfig()
+	config.MaxInFlight = 18 // perConnMaxInFlight = 18/6 = 3
+	consumer, err := NewConsumer("test", "ch", config)
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	close(consumer.exitChan) // drive RDY changes manually
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) { _, _ = c.Read(make([]byte, 4096)) }(c)
+		}
+	}()
+
+	mk := func(addr string, rdy int64) *Conn {
+		c := NewConn(addr, &consumer.config, &consumerConnDelegate{r: consumer})
+		tcp, derr := net.Dial("tcp", ln.Addr().String())
+		if derr != nil {
+			t.Fatalf("dial: %v", derr)
+		}
+		t.Cleanup(func() { tcp.Close() })
+		c.conn = tcp.(*net.TCPConn)
+		c.r = tcp
+		c.w = tcp
+		c.SetRDY(rdy)
+		consumer.mtx.Lock()
+		consumer.connections[addr] = c
+		consumer.mtx.Unlock()
+		atomic.AddInt64(&consumer.totalRdyCount, rdy)
+		return c
+	}
+
+	// Six connections balanced at the full budget: 6 * 3 == 18 == MaxInFlight.
+	conns := make([]*Conn, numConns)
+	for i := 0; i < numConns; i++ {
+		conns[i] = mk("10.0.0."+string(rune('1'+i))+":4150", 3)
+	}
+	if got := consumer.TotalRDY(); got != 18 {
+		t.Fatalf("setup: want totalRdyCount 18, got %d", got)
+	}
+
+	// The manager scales the consumer down. RDY must track the smaller budget.
+	consumer.ChangeMaxInFlight(12) // perConnMaxInFlight now 12/6 = 2
+
+	if total := consumer.TotalRDY(); total != 12 {
+		t.Fatalf("after MaxInFlight 18->12, want totalRdyCount 12, got %d "+
+			"(RDY not lowered: updateRDY refuses to reduce a connection while "+
+			"totalRdyCount > MaxInFlight)", total)
+	}
+	for i, c := range conns {
+		if c.RDY() != 2 {
+			t.Fatalf("conn %d: want RDY lowered to perConnMaxInFlight 2, got %d", i, c.RDY())
+		}
+	}
+}

--- a/rebalance_test.go
+++ b/rebalance_test.go
@@ -1,0 +1,72 @@
+package nsq
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+// TestRebalanceRDYRaisesStarvedConn verifies that when a connection set is at
+// its budget (existing connections hold all of MaxInFlight) and one connection
+// is under its fair share, rebalanceRDY lowers the over-holders and raises the
+// starved one to its perConnMaxInFlight share — the fresh-nsqd-after-roll case.
+func TestRebalanceRDYRaisesStarvedConn(t *testing.T) {
+	const numConns = 6
+	config := NewConfig()
+	config.MaxInFlight = 18 // perConnMaxInFlight = 18/6 = 3
+	consumer, err := NewConsumer("test", "ch", config)
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	close(consumer.exitChan) // quiesce rdyLoop
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) { _, _ = c.Read(make([]byte, 4096)) }(c)
+		}
+	}()
+
+	mk := func(addr string, rdy int64) *Conn {
+		c := NewConn(addr, &consumer.config, &consumerConnDelegate{r: consumer})
+		tcp, derr := net.Dial("tcp", ln.Addr().String())
+		if derr != nil {
+			t.Fatalf("dial: %v", derr)
+		}
+		t.Cleanup(func() { tcp.Close() })
+		c.conn = tcp.(*net.TCPConn)
+		c.r = tcp
+		c.w = tcp
+		c.SetRDY(rdy)
+		consumer.mtx.Lock()
+		consumer.connections[addr] = c
+		consumer.mtx.Unlock()
+		atomic.AddInt64(&consumer.totalRdyCount, rdy)
+		return c
+	}
+
+	// 5 established connections each over the fair share (RDY 4, total 20 > 18),
+	// and a freshly-connected one starved at RDY 0 — budget exhausted.
+	for i := 0; i < numConns-1; i++ {
+		mk("10.0.0."+string(rune('1'+i))+":4150", 4)
+	}
+	starved := mk("10.0.0.9:4150", 0)
+
+	consumer.rebalanceRDY()
+
+	if got := starved.RDY(); got != 3 {
+		t.Fatalf("starved conn: want RDY 3 (perConnMaxInFlight), got %d (totalRdy=%d)",
+			got, atomic.LoadInt64(&consumer.totalRdyCount))
+	}
+	if total := atomic.LoadInt64(&consumer.totalRdyCount); total != 18 {
+		t.Fatalf("want totalRdyCount 18 (6*3), got %d", total)
+	}
+}


### PR DESCRIPTION
## Problem
When an nsqd rolls to a new address, the consumer adds the new connection while the existing connections already hold the entire `MaxInFlight` budget. The newcomer's RDY request is refused (`ErrOverMaxInFlight`) and only limps up via gated redistribution — so one nsqd gets consumed at a fraction of its peers' rate (equal produce, equal connection count, **lower per-connection RDY**) and its channel backs up into the millions.

The connect path already lowered existing conns then raised the new one, but nothing re-asserted the share **after the set settled** (e.g. once the old connection closed), so a connection refused during the transient stayed starved indefinitely.

## Fix
`rebalanceRDY()`: lower over-provisioned connections first (freeing budget), then raise under-provisioned ones to `perConnMaxInFlight`. Called on every connection-set change (connect **and** close).

## Test
`TestRebalanceRDYRaisesStarvedConn` — 5 conns over-holding the full budget + 1 starved at RDY 0; after rebalance the starved conn gets its fair share and the total settles at the budget. Full suite passes against nsqd 1.2.1.

Stacks on the ConnStats branch (PR #4) since they're deployed together; will rebase to master order at merge.