### PR TITLE
consumer: expose per-connection RDY/in-flight and budget accounting

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -260,6 +260,12 @@ func (c *Conn) MaxRDY() int64 {
 	return c.maxRdyCount
 }
 
+// MessagesInFlight returns the number of messages currently in flight
+// (sent by nsqd over this connection, not yet finished or requeued).
+func (c *Conn) MessagesInFlight() int64 {
+	return atomic.LoadInt64(&c.messagesInFlight)
+}
+
 // LastRdyTime returns the time of the last non-zero RDY
 // update for this connection
 func (c *Conn) LastRdyTime() time.Time {

--- a/connstats_test.go
+++ b/connstats_test.go
@@ -1,0 +1,50 @@
+package nsq
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+// TestConnStatsReportsPerConnRDYAndInFlight verifies ConnStats returns the
+// per-nsqd RDY and in-flight counts for each connection.
+func TestConnStatsReportsPerConnRDYAndInFlight(t *testing.T) {
+	config := NewConfig()
+	config.MaxInFlight = 10
+	consumer, err := NewConsumer("test", "ch", config)
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	close(consumer.exitChan) // quiesce rdyLoop
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	mk := func(addr string, rdy, inflight int64) {
+		conn := NewConn(addr, &consumer.config, &consumerConnDelegate{r: consumer})
+		conn.SetRDY(rdy)
+		atomic.StoreInt64(&conn.messagesInFlight, inflight)
+		consumer.mtx.Lock()
+		consumer.connections[addr] = conn
+		consumer.mtx.Unlock()
+	}
+	mk("10.0.0.1:4150", 3, 2)
+	mk("10.0.0.2:4150", 0, 0)
+
+	got := map[string]ConnStat{}
+	for _, s := range consumer.ConnStats() {
+		got[s.Address] = s
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 conn stats, got %d", len(got))
+	}
+	if s := got["10.0.0.1:4150"]; s.RDY != 3 || s.InFlight != 2 {
+		t.Fatalf("conn1: want RDY 3 inflight 2, got RDY %d inflight %d", s.RDY, s.InFlight)
+	}
+	if s := got["10.0.0.2:4150"]; s.RDY != 0 || s.InFlight != 0 {
+		t.Fatalf("conn2: want RDY 0 inflight 0, got RDY %d inflight %d", s.RDY, s.InFlight)
+	}
+}

--- a/consumer.go
+++ b/consumer.go
@@ -205,6 +205,36 @@ func (r *Consumer) Stats() *ConsumerStats {
 	}
 }
 
+// ConnStat is a point-in-time view of a single nsqd connection's RDY and
+// in-flight counts, keyed by the nsqd address.
+type ConnStat struct {
+	Address  string
+	RDY      int64
+	InFlight int64
+	// Closing is true while the connection is being torn down. A closing
+	// connection still counts toward totalRdyCount but updateRDY refuses to
+	// change its RDY, so its budget cannot be reclaimed until it is removed.
+	Closing bool
+}
+
+// ConnStats returns per-connection RDY and in-flight counts for every nsqd
+// the consumer is currently connected to. It exists so callers can observe
+// how the MaxInFlight budget is distributed across connections (e.g. to spot
+// a single nsqd being under-provisioned with RDY relative to its peers).
+func (r *Consumer) ConnStats() []ConnStat {
+	conns := r.conns()
+	stats := make([]ConnStat, 0, len(conns))
+	for _, c := range conns {
+		stats = append(stats, ConnStat{
+			Address:  c.String(),
+			RDY:      c.RDY(),
+			InFlight: c.MessagesInFlight(),
+			Closing:  c.IsClosing(),
+		})
+	}
+	return stats
+}
+
 func (r *Consumer) conns() []*Conn {
 	r.mtx.RLock()
 	conns := make([]*Conn, 0, len(r.connections))
@@ -305,6 +335,14 @@ func (r *Consumer) IsStarved() bool {
 
 func (r *Consumer) getMaxInFlight() int32 {
 	return atomic.LoadInt32(&r.maxInFlight)
+}
+
+// TotalRDY returns the consumer's running total of RDY advertised across all
+// connections (the budget tracked against MaxInFlight). Comparing it to the sum
+// of per-connection RDY reveals budget leaked by connections that were removed
+// or are stuck closing without their RDY being reclaimed.
+func (r *Consumer) TotalRDY() int64 {
+	return atomic.LoadInt64(&r.totalRdyCount)
 }
 
 // ChangeMaxInFlight sets a new maximum number of messages this comsumer instance


### PR DESCRIPTION
Stacked on the RDY-lowering fix.

Adds `Consumer.ConnStats()` (per-connection address, RDY, in-flight, closing state) and `Consumer.TotalRDY()` so callers can observe how the `MaxInFlight` budget is distributed across nsqd connections and whether the running `totalRdyCount` matches it. These metrics are what surfaced and pinpointed the over-commitment bug fixed in the base PR.